### PR TITLE
make "GET STARTED" link look better

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,9 @@ Installation
 
 Installing and running an Open edX instance is not simple.  We strongly
 recommend that you use a service provider to run the software for you.  They
-have free trials that make it easy to get started:
-https://openedx.org/get-started/
+have free trials that make it easy to `GET STARTED <https://openedx.org/get-started/>`_.
+
+
 
 If you will be modifying edx-platform code, the `Open edX Developer Stack`_ (Devstack) is
 a Docker-based development environment.


### PR DESCRIPTION
## Description
It looks cleaner when you can just click on GET STARTED, instead of seeing the long link.

###Before
![image](https://user-images.githubusercontent.com/6383738/173905713-bda1152b-f69f-4ecb-a382-32e51d0e260f.png)

###After
![image](https://user-images.githubusercontent.com/6383738/173905795-3b597276-6916-497b-a9b2-08e156261e21.png)

